### PR TITLE
Fix auto-upgrade from SPDY/3 to SPDY/3.1

### DIFF
--- a/lib/spdy-transport/connection.js
+++ b/lib/spdy-transport/connection.js
@@ -243,7 +243,8 @@ Connection.prototype._onVersion = function _onVersion(version) {
   });
 
   // Update session window
-  if (state.version >= 3.1 || (state.isServer && state.autoSpdy31))
+  if (state.version >= 3.1 ||
+      (state.isServer && state.autoSpdy31 && state.version >= 3.1))
     this._onSessionWindowDrain();
 
   this.emit('version', version);
@@ -281,7 +282,7 @@ Connection.prototype._handleFrame = function _handleFrame(frame) {
 
   // Session window update
   if (frame.type === 'WINDOW_UPDATE' && frame.id === 0) {
-    if (state.version < 3.1 && state.autoSpdy31) {
+    if (state.version === 3 && state.autoSpdy31) {
       state.debug('id=0 switch version to 3.1');
       state.version = 3.1;
       this.emit('version', 3.1);
@@ -472,7 +473,8 @@ Connection.prototype._handleHeaders = function _handleHeaders(frame) {
 
 Connection.prototype._onSessionWindowDrain = function _onSessionWindowDrain() {
   var state = this._spdyState;
-  if (state.version < 3.1 && !(state.isServer && state.autoSpdy31))
+  if (state.version < 3.1 &&
+      !(state.isServer && state.autoSpdy31 && state.version >= 3.1))
     return;
 
   var delta = state.window.recv.getDelta();


### PR DESCRIPTION
The current code auto-upgrades all SPDY/3 clients to SPDY/3.1 when
operating in **plain** mode with **autoSpdy31** set to true. This seems
rather restrictive, implying that with autoSpdy31 set to true, the
server does not support SPDY/3-only clients.

This commit fixes this by only upgrading SPDY/3 clients to SPDY/3.1 when
the server receives a WINDOW_UPDATE for stream id 0. This ensures
that SPDY/3 clients can proceed uninhibited when operating in **plain**
mode, and ensuring that the autoSpdy31 option is only used for
SPDY/3.1 clients in **plain** mode, allowing for both SPDY/3 and
SPDY/3.1 clients to co-exist on the same server in **plain** mode.
